### PR TITLE
fix: Fix Houdini Indie wrong Windows application launcher

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,7 +20,9 @@ from pkg_resources import get_distribution, DistributionNotFound
 # Inject source onto path so that autodoc can find it by default, but in such a
 # way as to allow overriding location.
 sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..','source'))
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', 'source')
+    )
 )
 
 
@@ -29,7 +31,7 @@ try:
     # take major/minor/patch
     VERSION = '.'.join(release.split('.')[:3])
 except DistributionNotFound:
-     # package is not installed
+    # package is not installed
     VERSION = 'Unknown version'
 
 version = VERSION
@@ -56,16 +58,14 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'lowdown'
+    'lowdown',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # A list of prefixes to ignore for module listings.
-modindex_common_prefix = [
-    'ftrack-application-launcher.'
-]
+modindex_common_prefix = ['ftrack-application-launcher.']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
@@ -79,6 +79,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if building docs locally
     import sphinx_rtd_theme
+
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
@@ -102,12 +103,14 @@ def autodoc_skip(app, what, name, obj, skip, options):
 
     return skip
 
+
 # -- Todos ---------------------------------------------------------------------
 
 todo_include_todos = True
 autodoc_mock_imports = ['ftrack_action_handler']
 
 # -- Setup --------------------------------------------------------------------
+
 
 def setup(app):
     app.connect('autodoc-skip-member', autodoc_skip)

--- a/doc/source/examples/code-example.py
+++ b/doc/source/examples/code-example.py
@@ -1,5 +1,3 @@
-
-
 '''
 
 Import base modules and ensure the dependencies are available in the path.
@@ -20,13 +18,11 @@ import ftrack_api
 import ftrack_application_launcher
 
 
-
 '''
 
 Create launch action, to limit the context to be discovered.
 
 '''
-
 
 
 class LaunchAction(ftrack_application_launcher.ApplicationLaunchAction):
@@ -44,51 +40,56 @@ versions for the various operating systems.
 
 
 class ApplicationStore(ftrack_application_launcher.ApplicationStore):
-
     def _discover_applications(self):
         applications = []
 
         if self.current_os == 'darwin':
             prefix = ['/', 'Applications']
 
-            applications.extend(self._search_filesystem(
-                expression=prefix + ['Something.*', 'Something\\d[\\w.]+.app'],
-                label='An Application',
-                variant='{version}',
-                applicationIdentifier='an-application_{variant}',
-                icon='an_application',
-                integrations={'example': ['ftrack-example-integration']},
-                launchArguments=["--arguments"],
-
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix
+                    + ['Something.*', 'Something\\d[\\w.]+.app'],
+                    label='An Application',
+                    variant='{version}',
+                    applicationIdentifier='an-application_{variant}',
+                    icon='an_application',
+                    integrations={'example': ['ftrack-example-integration']},
+                    launchArguments=["--arguments"],
+                )
+            )
 
         if self.current_os == 'windows':
             prefix = ['C:\\', 'Program Files.*']
 
-            applications.extend(self._search_filesystem(
-                expression=prefix + ["Something.*", "Something\\d.+.exe"],
-                label='An Application',
-                variant='{version}',
-                applicationIdentifier='an-application_{variant}',
-                versionExpression="(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)",
-                icon='an_application',
-                integrations={'example': ['ftrack-example-integration']},
-                launchArguments=["--arguments"],
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix + ["Something.*", "Something\\d.+.exe"],
+                    label='An Application',
+                    variant='{version}',
+                    applicationIdentifier='an-application_{variant}',
+                    versionExpression="(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)",
+                    icon='an_application',
+                    integrations={'example': ['ftrack-example-integration']},
+                    launchArguments=["--arguments"],
+                )
+            )
 
         if self.current_os == 'linux':
             prefix = ["/", "usr", "local", "Something.*"]
 
-            applications.extend(self._search_filesystem(
-                expression=prefix +["Something.*", "Something\\d.+.exe"],
-                label='An Application',
-                variant='{version}',
-                applicationIdentifier='an-application_{variant}',
-                versionExpression="(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)",
-                icon='an_application',
-                integrations={'example': ['ftrack-example-integration']},
-                launchArguments=["--arguments"],
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix + ["Something.*", "Something\\d.+.exe"],
+                    label='An Application',
+                    variant='{version}',
+                    applicationIdentifier='an-application_{variant}',
+                    versionExpression="(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)",
+                    icon='an_application',
+                    integrations={'example': ['ftrack-example-integration']},
+                    launchArguments=["--arguments"],
+                )
+            )
 
         return applications
 
@@ -98,6 +99,7 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
 Create application launcher, to let use the default launch action mechanism.
 
 '''
+
 
 class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
     '''
@@ -134,4 +136,3 @@ def register(session, **kw):
     # Create action and register to respond to discover and launch events.
     action = LaunchAction(session, application_store, launcher, priority=1000)
     action.register()
-

--- a/doc/source/examples/discover-integration-example.py
+++ b/doc/source/examples/discover-integration-example.py
@@ -16,22 +16,13 @@ def on_application_launch(session, event):
 
     # gather local paths
     plugin_base_dir = os.path.normpath(
-        os.path.join(
-            os.path.abspath(
-                os.path.dirname(__file__)
-            ),
-            '..'
-        )
+        os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
     )
 
-    hook_path = os.path.join(
-       plugin_base_dir, 'resource', 'hook'
-    )
+    hook_path = os.path.join(plugin_base_dir, 'resource', 'hook')
 
     # Add dependencies to PATH.
-    python_dependencies = os.path.join(
-        plugin_base_dir, 'dependencies'
-    )
+    python_dependencies = os.path.join(plugin_base_dir, 'dependencies')
     sys.path.append(python_dependencies)
 
     # Get the context is running from.
@@ -44,11 +35,17 @@ def on_application_launch(session, event):
             'version': '0.0.0',
             'env': {
                 'FTRACK_EVENT_PLUGIN_PATH.prepend': hook_path,
-                'PYTHONPATH.prepend': os.path.pathsep.join([python_dependencies]),
+                'PYTHONPATH.prepend': os.path.pathsep.join(
+                    [python_dependencies]
+                ),
                 'FTRACK_CONTEXTID.set': task['id'],
-                'FS.set': task['parent']['custom_attributes'].get('fstart', '1.0'),
-                'FE.set': task['parent']['custom_attributes'].get('fend', '100.0')
-            }
+                'FS.set': task['parent']['custom_attributes'].get(
+                    'fstart', '1.0'
+                ),
+                'FE.set': task['parent']['custom_attributes'].get(
+                    'fend', '100.0'
+                ),
+            },
         }
     }
 
@@ -69,11 +66,13 @@ def register(session):
         'topic=ftrack.connect.application.launch and '
         'data.application.identifier=an_application*'
         ' and data.application.version >= 2021',
-        handle_event, priority=40
+        handle_event,
+        priority=40,
     )
     session.event_hub.subscribe(
         'topic=ftrack.connect.application.discover and '
         'data.application.identifier=an_application*'
         ' and data.application.version >= 2021',
-        handle_event, priority=40
+        handle_event,
+        priority=40,
     )

--- a/doc/source/release/release_notes.rst
+++ b/doc/source/release/release_notes.rst
@@ -8,13 +8,6 @@
 Release Notes
 *************
 
-.. release:: upcoming
-
-    .. change:: fixed
-        :tags: houdini
-
-        Houdini Indie executable fix.
-
 .. release:: 1.0.6
     :date: 2022-09-05
 

--- a/doc/source/release/release_notes.rst
+++ b/doc/source/release/release_notes.rst
@@ -8,6 +8,13 @@
 Release Notes
 *************
 
+.. release:: upcoming
+
+    .. change:: fixed
+        :tags: houdini
+
+        Houdini Indie executable fix.
+
 .. release:: 1.0.6
     :date: 2022-09-05
 

--- a/resource/config/houdini-indie-connector.json
+++ b/resource/config/houdini-indie-connector.json
@@ -17,7 +17,7 @@
         },
         "windows": {
             "prefix":["C:\\", "Program Files.*"],
-            "expression":["Side Effects Software", "Houdini*", "bin", "houdini.exe"]
+            "expression":["Side Effects Software", "Houdini*", "bin", "hindie.exe"]
         },
         "darwin": {
             "prefix":["/", "Applications"],

--- a/resource/config/houdini-indie-pipeline.json
+++ b/resource/config/houdini-indie-pipeline.json
@@ -22,7 +22,7 @@
         },
         "windows": {
             "prefix":["C:\\", "Program Files.*"],
-            "expression":["Side Effects Software", "Houdini*", "bin", "houdini.exe"]
+            "expression":["Side Effects Software", "Houdini*", "bin", "hindie.exe"]
         },
         "darwin": {
             "prefix":["/", "Applications"],

--- a/resource/hook/application_launcher.py
+++ b/resource/hook/application_launcher.py
@@ -7,7 +7,9 @@ sources = os.path.abspath(os.path.join(cwd, '..', 'dependencies'))
 sys.path.append(sources)
 
 import ftrack_api
-from ftrack_application_launcher.discover_applications import DiscoverApplications
+from ftrack_application_launcher.discover_applications import (
+    DiscoverApplications,
+)
 from ftrack_application_launcher._version import __version__
 
 logging.basicConfig(level=logging.INFO)
@@ -26,8 +28,7 @@ def register(api_object, **kw):
 
     # Ensure the config path is in form of a list
     config_paths = os.environ.setdefault(
-        'FTRACK_APPLICATION_LAUNCHER_CONFIG_PATHS',
-        default_config_path
+        'FTRACK_APPLICATION_LAUNCHER_CONFIG_PATHS', default_config_path
     ).split(os.path.pathsep)
 
     logging.debug(

--- a/resource/hook/ftrack_connect_adobe_hook.py
+++ b/resource/hook/ftrack_connect_adobe_hook.py
@@ -23,17 +23,17 @@ import ftrack_application_launcher
 
 #: Custom version expression to match versions `2015.5` and `2015`
 #  as distinct versions.
-ADOBE_VERSION_EXPRESSION = re.compile(
-    r'(?P<version>\d[\d.]*)[^\w\d]'
-)
+ADOBE_VERSION_EXPRESSION = re.compile(r'(?P<version>\d[\d.]*)[^\w\d]')
+
 
 class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
     '''Adobe plugins discover and launch action.'''
+
     context = [None, 'Task', 'AssetVersion']
     identifier = 'ftrack-connect-launch-adobe'
     label = 'Adobe'
 
-    def __init__(self, session,  application_store, launcher):
+    def __init__(self, session, application_store, launcher):
         '''Initialise action with *applicationStore* and *launcher*.
 
         *applicationStore* should be an instance of
@@ -47,16 +47,14 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
             session=session,
             application_store=application_store,
             launcher=launcher,
-            priority=0
+            priority=0,
         )
 
     def _discover(self, event):
         '''Return discovered applications.'''
 
         entities, event = self._translate_event(self.session, event)
-        if not self.validate_selection(
-            entities
-        ):
+        if not self.validate_selection(entities):
             return
 
         selection = event['data'].get('selection', [])
@@ -69,33 +67,35 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
         for application in applications:
             applicationIdentifier = application['identifier']
             label = application['label']
-            items.append({
-                'actionIdentifier': self.identifier,
-                'label': label,
-                'variant': application.get('variant', None),
-                'description': application.get('description', None),
-                'icon': application.get('icon', 'default'),
-                'applicationIdentifier': applicationIdentifier,
-                'host': platform.node()
-            })
-
-            if selection:
-                items.append({
+            items.append(
+                {
                     'actionIdentifier': self.identifier,
                     'label': label,
-                    'variant': '{variant} with latest version'.format(
-                        variant=application.get('variant', '')
-                    ),
+                    'variant': application.get('variant', None),
                     'description': application.get('description', None),
                     'icon': application.get('icon', 'default'),
-                    'launchWithLatest': True,
                     'applicationIdentifier': applicationIdentifier,
-                    'host': platform.node()
-                })
+                    'host': platform.node(),
+                }
+            )
 
-        return {
-            'items': items
-        }
+            if selection:
+                items.append(
+                    {
+                        'actionIdentifier': self.identifier,
+                        'label': label,
+                        'variant': '{variant} with latest version'.format(
+                            variant=application.get('variant', '')
+                        ),
+                        'description': application.get('description', None),
+                        'icon': application.get('icon', 'default'),
+                        'launchWithLatest': True,
+                        'applicationIdentifier': applicationIdentifier,
+                        'host': platform.node(),
+                    }
+                )
+
+        return {'items': items}
 
     def _launch(self, event):
         '''Handle *event*.
@@ -109,9 +109,7 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
         event.stop()
         entities, event = self._translate_event(self.session, event)
 
-        if not self.validate_selection(
-            entities
-        ):
+        if not self.validate_selection(entities):
             self.logger.warning('No valid selection')
             return
 
@@ -127,10 +125,7 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
             entity_type, entity_id = entities[0]
             resolved_entity = self.session.get(entity_type, entity_id)
 
-            if (
-                selection and
-                resolved_entity.entity_type == 'AssetVersion'
-            ):
+            if selection and resolved_entity.entity_type == 'AssetVersion':
 
                 entityId = resolved_entity.get('task_id')
 
@@ -140,14 +135,11 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
 
                     entityId = entity['id']
 
-                context['selection'] = [{
-                    'entityId': entityId,
-                    'entityType': 'task'
-                }]
+                context['selection'] = [
+                    {'entityId': entityId, 'entityType': 'task'}
+                ]
 
-        return self.launcher.launch(
-            application_identifier, context
-        )
+        return self.launcher.launch(application_identifier, context)
 
     def get_version_information(self, event):
         '''Return version information.'''
@@ -155,27 +147,20 @@ class LaunchAdobeAction(ftrack_application_launcher.ApplicationLaunchAction):
         # of the plugins at the moment. Once ExManCMD is bundled with Connect
         # we can update this to return information about installed extensions.
         return [
-            dict(
-                name='ftrack connect photoshop',
-                version='-'
-            ), 
+            dict(name='ftrack connect photoshop', version='-'),
             # dict(
             #     name='ftrack connect premiere',
             #     version='-'
-            # ), 
+            # ),
             # dict(
             #     name='ftrack connect after effects',
             #     version='-'
-            # ), 
-            dict(
-                name='ftrack connect illustrator',
-                version='-'
-            )
+            # ),
+            dict(name='ftrack connect illustrator', version='-'),
         ]
 
 
 class ApplicationStore(ftrack_application_launcher.ApplicationStore):
-
     def _discover_applications(self):
         '''Return a list of applications that can be launched from this host.
 
@@ -197,16 +182,20 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
         if sys.platform == 'darwin':
             prefix = ['/', 'Applications']
 
-            applications.extend(self._search_filesystem(
-                expression=prefix + [
-                    r'Adobe Photoshop ((?:CC )?\d+)', r'Adobe Photoshop ((?:CC )?\d+)\.app'
-                ],
-                label='Photoshop',
-                variant='CC {version}',
-                applicationIdentifier='photoshop_{variant}',
-                versionExpression=ADOBE_VERSION_EXPRESSION,
-                icon='photoshop'
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix
+                    + [
+                        r'Adobe Photoshop ((?:CC )?\d+)',
+                        r'Adobe Photoshop ((?:CC )?\d+)\.app',
+                    ],
+                    label='Photoshop',
+                    variant='CC {version}',
+                    applicationIdentifier='photoshop_{variant}',
+                    versionExpression=ADOBE_VERSION_EXPRESSION,
+                    icon='photoshop',
+                )
+            )
 
             # applications.extend(self._search_filesystem(
             #     expression=prefix + [
@@ -230,32 +219,41 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
             #     icon='after_effects'
             # ))
 
-            applications.extend(self._search_filesystem(
-                expression=prefix + [
-                    r'Adobe Illustrator ((?:CC )?\d+)', r'Adobe Illustrator ?((?:CC )?\d+)?\.app'
-                ],
-                label='Illustrator',
-                variant='CC {version}',
-                applicationIdentifier='illustrator_{variant}',
-                versionExpression=ADOBE_VERSION_EXPRESSION,
-                icon='illustrator'
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix
+                    + [
+                        r'Adobe Illustrator ((?:CC )?\d+)',
+                        r'Adobe Illustrator ?((?:CC )?\d+)?\.app',
+                    ],
+                    label='Illustrator',
+                    variant='CC {version}',
+                    applicationIdentifier='illustrator_{variant}',
+                    versionExpression=ADOBE_VERSION_EXPRESSION,
+                    icon='illustrator',
+                )
+            )
 
         elif sys.platform == 'win32':
             prefix = ['C:\\', 'Program Files.*']
 
-            applications.extend(self._search_filesystem(
-                expression=(
-                    prefix +
-                    ['Adobe', r'Adobe Photoshop ((?:CC )?\d+)',
-                     'Photoshop.exe']
-                ),
-                label='Photoshop',
-                variant='CC {version}',
-                applicationIdentifier='photoshop_{variant}',
-                versionExpression=ADOBE_VERSION_EXPRESSION,
-                icon='photoshop'
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=(
+                        prefix
+                        + [
+                            'Adobe',
+                            r'Adobe Photoshop ((?:CC )?\d+)',
+                            'Photoshop.exe',
+                        ]
+                    ),
+                    label='Photoshop',
+                    variant='CC {version}',
+                    applicationIdentifier='photoshop_{variant}',
+                    versionExpression=ADOBE_VERSION_EXPRESSION,
+                    icon='photoshop',
+                )
+            )
 
             # applications.extend(self._search_filesystem(
             #     expression=(
@@ -283,18 +281,26 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
             #     icon='after_effects'
             # ))
 
-            applications.extend(self._search_filesystem(
-                expression=(
-                    prefix +
-                    ['Adobe', r'Adobe Illustrator ((?:CC )?\d+)', 'Support Files',
-                     'Contents', 'Windows', 'Illustrator.exe']
-                ),
-                label='Illustrator',
-                variant='CC {version}',
-                applicationIdentifier='illustrator_{variant}',
-                versionExpression=ADOBE_VERSION_EXPRESSION,
-                icon='illustrator'
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=(
+                        prefix
+                        + [
+                            'Adobe',
+                            r'Adobe Illustrator ((?:CC )?\d+)',
+                            'Support Files',
+                            'Contents',
+                            'Windows',
+                            'Illustrator.exe',
+                        ]
+                    ),
+                    label='Illustrator',
+                    variant='CC {version}',
+                    applicationIdentifier='illustrator_{variant}',
+                    versionExpression=ADOBE_VERSION_EXPRESSION,
+                    icon='illustrator',
+                )
+            )
 
         self.logger.debug(
             'Discovered applications:\n{0}'.format(
@@ -336,9 +342,11 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
         their file system path.
 
         '''
-        self.logger.debug('Looking for latest version of {} {} {}'.format(
-            entityId, entityType, extension
-        ))
+        self.logger.debug(
+            'Looking for latest version of {} {} {}'.format(
+                entityId, entityType, extension
+            )
+        )
         if entityType == 'task':
             versions = self.session.query(
                 'select components from AssetVersion where task.id is {}'.format(
@@ -359,10 +367,7 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
                 (
                     'Unable to find latest version from entityId={entityId} '
                     'with entityType={entityType}.'
-                ).format(
-                    entityId=entityId,
-                    entityType=entityType
-                )
+                ).format(entityId=entityId, entityType=entityType)
             )
             return None
 
@@ -378,10 +383,7 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
 
                 file_system_path = self.location.get_filesystem_path(component)
                 if file_system_path and file_system_path.endswith(extension):
-                    if (
-                            last_date is None or
-                            version['date'] > last_date
-                    ):
+                    if last_date is None or version['date'] > last_date:
                         latest_component = component
                         last_date = version['date']
 
@@ -401,9 +403,7 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
 
         command = super(
             ApplicationLauncher, self
-        )._get_application_launch_command(
-            application, context
-        )
+        )._get_application_launch_command(application, context)
 
         if command is not None and context is not None:
             self.logger.debug(
@@ -419,20 +419,22 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
                 component = None
                 file_system_path = None
 
-                for identifier, extension in self.application_extensions.items():
+                for (
+                    identifier,
+                    extension,
+                ) in self.application_extensions.items():
                     if application['identifier'].startswith(identifier):
-                        component , file_system_path = self._find_latest_component(
-                            entity['entityId'],
-                            entity['entityType'],
-                            extension
+                        (
+                            component,
+                            file_system_path,
+                        ) = self._find_latest_component(
+                            entity['entityId'], entity['entityType'], extension
                         )
                         break
 
                 if component is not None and file_system_path is not None:
 
-                    file_path = self._get_temporary_copy(
-                        file_system_path
-                    )
+                    file_path = self._get_temporary_copy(file_system_path)
                     self.logger.info(
                         u'Launching application with file {0!r}'.format(
                             file_path

--- a/resource/hook/ftrack_connect_rv_hook.py
+++ b/resource/hook/ftrack_connect_rv_hook.py
@@ -20,9 +20,7 @@ sys.path.append(sources)
 import ftrack_api
 import ftrack_application_launcher
 
-RV_INSTALLATION_PATH = os.getenv(
-    'RV_INSTALLATION_PATH', '/usr/local/rv'
-)
+RV_INSTALLATION_PATH = os.getenv('RV_INSTALLATION_PATH', '/usr/local/rv')
 
 
 class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
@@ -38,9 +36,7 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
         )._get_application_environment(application, context)
 
         environment = ftrack_application_launcher.append_path(
-            sources,
-            'PYTHONPATH',
-            environment
+            sources, 'PYTHONPATH', environment
         )
 
         return environment
@@ -48,11 +44,12 @@ class ApplicationLauncher(ftrack_application_launcher.ApplicationLauncher):
 
 class LaunchRvAction(ftrack_application_launcher.ApplicationLaunchAction):
     '''Adobe plugins discover and launch action.'''
+
     context = [None, 'Task', 'AssetVersion']
     identifier = 'ftrack-connect-launch-rv'
     label = 'rv'
 
-    def __init__(self, session,  application_store, launcher):
+    def __init__(self, session, application_store, launcher):
         '''Initialise action with *applicationStore* and *launcher*.
 
         *applicationStore* should be an instance of
@@ -66,9 +63,8 @@ class LaunchRvAction(ftrack_application_launcher.ApplicationLaunchAction):
             session=session,
             application_store=application_store,
             launcher=launcher,
-            priority=0
+            priority=0,
         )
-
 
     def _create_temp_data(self, data, expiry=None):
 
@@ -79,8 +75,8 @@ class LaunchRvAction(ftrack_application_launcher.ApplicationLaunchAction):
             'action': 'create',
             'type': 'tempdata',
             'data': data,
-            'expiry': expiry
-        }   
+            'expiry': expiry,
+        }
 
         return self.session.call(action)
 
@@ -92,19 +88,14 @@ class LaunchRvAction(ftrack_application_launcher.ApplicationLaunchAction):
             *applicationIdentifier* to identify which application to start.
 
         '''
-        applicationIdentifier = (
-            event['data']['applicationIdentifier']
-        )
+        applicationIdentifier = event['data']['applicationIdentifier']
 
         context = event['data'].copy()
 
-        return self.launcher.launch(
-            applicationIdentifier, context
-        )
+        return self.launcher.launch(applicationIdentifier, context)
 
 
 class ApplicationStore(ftrack_application_launcher.ApplicationStore):
-
     def _discover_applications(self):
         '''Return a list of applications that can be launched from this host.
 
@@ -125,36 +116,37 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
 
         if self.current_os == 'darwin':
             prefix = ['/', 'Applications']
-            applications.extend(self._search_filesystem(
-                expression=prefix + ['RV.*\.app'],
-                label='Review with RV',
-                variant='{version}',
-                applicationIdentifier='rv_{variant}_with_review',
-                icon='rv',
-                launchArguments=[
-                    '--args', '-flags', 'ModeManagerPreload=ftrack'
-                ],
-                integrations={'legacy':['ftrack-connect-rv']}
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix + ['RV.*\.app'],
+                    label='Review with RV',
+                    variant='{version}',
+                    applicationIdentifier='rv_{variant}_with_review',
+                    icon='rv',
+                    launchArguments=[
+                        '--args',
+                        '-flags',
+                        'ModeManagerPreload=ftrack',
+                    ],
+                    integrations={'legacy': ['ftrack-connect-rv']},
+                )
+            )
 
         elif self.current_os == 'windows':
             prefix = ['C:\\', 'Program Files.*']
-            applications.extend(self._search_filesystem(
-                expression=prefix + [
-                    '[Tweak|Shotgun]', 'RV.\d.+', 'bin', 'rv.exe'
-                ],
-                label='Review with RV',
-                variant='{version}',
-                applicationIdentifier='rv_{variant}_with_review',
-                icon='rv',
-                launchArguments=[
-                    '-flags', 'ModeManagerPreload=ftrack'
-                ],
-                versionExpression=re.compile(
-                    r'(?P<version>\d+.\d+.\d+)'
-                ),
-                integrations={'legacy':['ftrack-connect-rv']}
-            ))
+            applications.extend(
+                self._search_filesystem(
+                    expression=prefix
+                    + ['[Tweak|Shotgun]', 'RV.\d.+', 'bin', 'rv.exe'],
+                    label='Review with RV',
+                    variant='{version}',
+                    applicationIdentifier='rv_{variant}_with_review',
+                    icon='rv',
+                    launchArguments=['-flags', 'ModeManagerPreload=ftrack'],
+                    versionExpression=re.compile(r'(?P<version>\d+.\d+.\d+)'),
+                    integrations={'legacy': ['ftrack-connect-rv']},
+                )
+            )
 
         elif self.current_os == 'linux':
             separator = os.path.sep
@@ -179,19 +171,21 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
                     # Add leading slash back
                     prefix.insert(0, separator)
 
-                applications.extend(self._search_filesystem(
-                    expression=prefix + [
-                        'rv-centos7-x86-64-\d.+', 'bin', 'rv$'
-                    ],
-                    label='Review with RV',
-                    variant='{version}',
-                    applicationIdentifier='rv_{variant}_with_review',
-                    icon='rv',
-                    launchArguments=[
-                        '-flags', 'ModeManagerPreload=ftrack'
-                    ],
-                    integrations={'legacy':['ftrack-connect-rv']}
-                ))
+                applications.extend(
+                    self._search_filesystem(
+                        expression=prefix
+                        + ['rv-centos7-x86-64-\d.+', 'bin', 'rv$'],
+                        label='Review with RV',
+                        variant='{version}',
+                        applicationIdentifier='rv_{variant}_with_review',
+                        icon='rv',
+                        launchArguments=[
+                            '-flags',
+                            'ModeManagerPreload=ftrack',
+                        ],
+                        integrations={'legacy': ['ftrack-connect-rv']},
+                    )
+                )
 
         self.logger.debug(
             'Discovered applications:\n{0}'.format(
@@ -205,9 +199,7 @@ class ApplicationStore(ftrack_application_launcher.ApplicationStore):
 def register(session, **kw):
     '''Register hooks.'''
 
-    logger = logging.getLogger(
-        'ftrack_plugin:ftrack_connect_rv_hook.register'
-    )
+    logger = logging.getLogger('ftrack_plugin:ftrack_connect_rv_hook.register')
 
     # Validate that registry is ftrack.EVENT_HANDLERS. If not, assume that
     # register is being called from a new or incompatible API and
@@ -219,9 +211,7 @@ def register(session, **kw):
     application_store = ApplicationStore(session)
 
     # Create a launcher with the store containing applications.
-    launcher = ApplicationLauncher(
-        application_store
-    )
+    launcher = ApplicationLauncher(application_store)
 
     # Create action and register to respond to discover and launch actions.
     action = LaunchRvAction(session, application_store, launcher)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ __version__ = {version!r}
 '''
 
 
-
 class BuildPlugin(Command):
     '''Build plugin.'''
 
@@ -53,6 +52,7 @@ class BuildPlugin(Command):
     def run(self):
         '''Run the build step.'''
         import setuptools_scm
+
         release = setuptools_scm.get_version(version_scheme='post-release')
         VERSION = '.'.join(release.split('.')[:3])
         global STAGING_PATH
@@ -63,33 +63,29 @@ class BuildPlugin(Command):
         shutil.rmtree(STAGING_PATH, ignore_errors=True)
 
         # Copy hook files
-        shutil.copytree(
-            CONFIG_PATH,
-            os.path.join(STAGING_PATH, 'config')
-        )
+        shutil.copytree(CONFIG_PATH, os.path.join(STAGING_PATH, 'config'))
 
         # Copy hook files
-        shutil.copytree(
-            HOOK_PATH,
-            os.path.join(STAGING_PATH, 'hook')
-        )
+        shutil.copytree(HOOK_PATH, os.path.join(STAGING_PATH, 'hook'))
 
         # Install local dependencies
         subprocess.check_call(
             [
-                sys.executable, '-m', 'pip', 'install','.','--target',  
-                os.path.join(STAGING_PATH, 'dependencies')
+                sys.executable,
+                '-m',
+                'pip',
+                'install',
+                '.',
+                '--target',
+                os.path.join(STAGING_PATH, 'dependencies'),
             ]
         )
 
         # Generate plugin zip
         shutil.make_archive(
-            os.path.join(
-                BUILD_PATH,
-                PLUGIN_NAME.format(VERSION)
-            ),
+            os.path.join(BUILD_PATH, PLUGIN_NAME.format(VERSION)),
             'zip',
-            STAGING_PATH
+            STAGING_PATH,
         )
 
 
@@ -105,27 +101,24 @@ setup(
     license='Apache License (2.0)',
     packages=find_packages(SOURCE_PATH),
     package_dir={'': 'source'},
-    setup_requires=[
-        'setuptools>=45.0.0',
-        'setuptools_scm'
-    ],
+    setup_requires=['setuptools>=45.0.0', 'setuptools_scm'],
     tests_require=['pytest >= 2.3.5, < 3'],
     use_scm_version={
         'write_to': 'source/ftrack_application_launcher/_version.py',
         'write_to_template': version_template,
-        'version_scheme': 'post-release'
+        'version_scheme': 'post-release',
     },
     install_requires=[
         'ftrack-python-api >= 2, < 3',
         'ftrack-action-handler',
-        'future'
+        'future',
     ],
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 3',
     ],
     cmdclass={'build_plugin': BuildPlugin},
     zip_safe=False,
-    python_requires=">=3, <4"
+    python_requires=">=3, <4",
 )

--- a/source/ftrack_application_launcher/asynchronous.py
+++ b/source/ftrack_application_launcher/asynchronous.py
@@ -25,9 +25,7 @@ def asynchronous(method):
                 sys.excepthook(*sys.exc_info())
 
         thread = threading.Thread(
-            target=exceptHookWrapper,
-            args=args,
-            kwargs=kwargs
+            target=exceptHookWrapper, args=args, kwargs=kwargs
         )
         thread.start()
 

--- a/source/ftrack_application_launcher/configure_logging.py
+++ b/source/ftrack_application_launcher/configure_logging.py
@@ -29,7 +29,9 @@ def get_log_directory():
     return log_directory
 
 
-def configure_logging(logger_name, level=None, format=None, extra_modules=None):
+def configure_logging(
+    logger_name, level=None, format=None, extra_modules=None
+):
     '''Configure `loggerName` loggers with console and file handler.
 
     Optionally specify log *level* (default WARNING)
@@ -41,13 +43,14 @@ def configure_logging(logger_name, level=None, format=None, extra_modules=None):
     '''
 
     # Provide default values for level and format.
-    format = format or '%(levelname)s - %(threadName)s - %(asctime)s - %(name)s - %(message)s'
+    format = (
+        format
+        or '%(levelname)s - %(threadName)s - %(asctime)s - %(name)s - %(message)s'
+    )
     level = level or logging.WARNING
 
     log_directory = get_log_directory()
-    logfile = os.path.join(
-        log_directory, '{0}.log'.format(logger_name)
-    )
+    logfile = os.path.join(log_directory, '{0}.log'.format(logger_name))
 
     # Sanitise the variable, checking the type.
     if not isinstance(extra_modules, (list, tuple, type(None))):
@@ -84,20 +87,12 @@ def configure_logging(logger_name, level=None, format=None, extra_modules=None):
                 'maxBytes': 10485760,
                 'backupCount': 5,
             },
-
         },
         'filters': {'application_launcher_only': {'name': logger_name}},
-        'formatters': {
-            'file': {
-                'format': format
-            }
-        },
+        'formatters': {'file': {'format': format}},
         'loggers': {
-            logger_name: {
-                'level': 'DEBUG',
-                'handlers': ['console','file']               
-            }
-        }
+            logger_name: {'level': 'DEBUG', 'handlers': ['console', 'file']}
+        },
     }
 
     for module in modules:

--- a/source/ftrack_application_launcher/discover_applications.py
+++ b/source/ftrack_application_launcher/discover_applications.py
@@ -4,11 +4,14 @@ import json
 import platform
 from collections import defaultdict
 import logging
-from ftrack_application_launcher import ApplicationStore, ApplicationLaunchAction, ApplicationLauncher
+from ftrack_application_launcher import (
+    ApplicationStore,
+    ApplicationLaunchAction,
+    ApplicationLauncher,
+)
 
 
 class DiscoverApplications(object):
-
     @property
     def current_os(self):
         return platform.system().lower()
@@ -33,7 +36,9 @@ class DiscoverApplications(object):
 
         loaded_filtered_files = []
         for config_path in config_paths:
-            if not os.path.exists(config_path) or not os.path.isdir(config_path):
+            if not os.path.exists(config_path) or not os.path.isdir(
+                config_path
+            ):
                 self.logger.warning(
                     '{} directory cannot be found.'.format(config_path)
                 )
@@ -55,7 +60,7 @@ class DiscoverApplications(object):
                             config, error
                         )
                     )
-        
+
         return loaded_filtered_files
 
     def _group_configurations(self, configurations):
@@ -63,14 +68,21 @@ class DiscoverApplications(object):
         result_dict = defaultdict(list)
 
         for configuration in configurations:
-            result_dict.setdefault(configuration['identifier'], []).append(configuration)
+            result_dict.setdefault(configuration['identifier'], []).append(
+                configuration
+            )
 
         return result_dict
 
     def _build_launchers(self, configurations):
         grouped_configurations = self._group_configurations(configurations)
-        for identifier, identified_configuration in grouped_configurations.items():
-            self.logger.debug('building config store for {}'.format(identifier))
+        for (
+            identifier,
+            identified_configuration,
+        ) in grouped_configurations.items():
+            self.logger.debug(
+                'building config store for {}'.format(identifier)
+            )
             store = ApplicationStore(self._session)
 
             for config in identified_configuration:
@@ -98,7 +110,7 @@ class DiscoverApplications(object):
                     icon=config['icon'],
                     variant=config['variant'],
                     launchArguments=launch_arguments,
-                    integrations=config.get('integrations')
+                    integrations=config.get('integrations'),
                 )
                 store.applications.extend(applications)
 
@@ -109,19 +121,22 @@ class DiscoverApplications(object):
                 {
                     'label': config['label'],
                     'identifier': identifier,
-                    'context': config['context']
-                }
+                    'context': config['context'],
+                },
             )
             priority = config.get('priority', sys.maxsize)
-            action = NewAction(self._session, store, launcher, priority=priority)
+            action = NewAction(
+                self._session, store, launcher, priority=priority
+            )
 
-            self.logger.debug('Creating App launcher {} with priority {}'.format(action, priority))
+            self.logger.debug(
+                'Creating App launcher {} with priority {}'.format(
+                    action, priority
+                )
+            )
 
             self._actions.append(action)
 
     def register(self):
         for action in self._actions:
             action.register()
-
-
-

--- a/source/ftrack_application_launcher/usage.py
+++ b/source/ftrack_application_launcher/usage.py
@@ -26,8 +26,8 @@ def _send_event(session, event_name, metadata=None):
                 'data': {
                     'type': 'event',
                     'name': event_name,
-                    'metadata': data
-                }
+                    'metadata': data,
+                },
             }
         )
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-3tex9ph
  * ZENDESK-98196

-->

Resolves <!--Task reference -->

- [X] The PR contains updates to the release notes.

## Changes

- Fix Houdini Indie wrong Windows application launcher
- Run Black

 
## Test

Test launch of Houdini Indie on Windows, the correct executable should now be run.
