### PR TITLE
fix: Houdini Core, FX and Apprentice Windows executable alignment

### DIFF
--- a/doc/source/release/release_notes.rst
+++ b/doc/source/release/release_notes.rst
@@ -8,6 +8,13 @@
 Release Notes
 *************
 
+.. release:: upcoming
+
+    .. change:: fixed
+        :tags: houdini
+
+        Houdini Core, FX and Apprentice Windows executable alignment.
+
 .. release:: 1.0.7
     :date: 2022-11-21
 

--- a/resource/config/houdini-apprentice-pipeline.json
+++ b/resource/config/houdini-apprentice-pipeline.json
@@ -22,7 +22,7 @@
         },
         "windows": {
             "prefix":["C:\\", "Program Files.*"],
-            "expression":["Side Effects Software", "Houdini*", "bin", "houdini.exe"]
+            "expression":["Side Effects Software", "Houdini*", "bin", "happrentice.exe"]
         },
         "darwin": {
             "prefix":["/", "Applications"],

--- a/resource/config/houdini-core-pipeline.json
+++ b/resource/config/houdini-core-pipeline.json
@@ -22,7 +22,7 @@
         },
         "windows": {
             "prefix":["C:\\", "Program Files.*"],
-            "expression":["Side Effects Software", "Houdini*", "bin", "houdini.exe"]
+            "expression":["Side Effects Software", "Houdini*", "bin", "houdinicore.exe"]
         },
         "darwin": {
             "prefix":["/", "Applications"],

--- a/resource/config/houdini-fx-pipeline.json
+++ b/resource/config/houdini-fx-pipeline.json
@@ -22,7 +22,7 @@
         },
         "windows": {
             "prefix":["C:\\", "Program Files.*"],
-            "expression":["Side Effects Software", "Houdini*", "bin", "houdini.exe"]
+            "expression":["Side Effects Software", "Houdini*", "bin", "houdinifx.exe"]
         },
         "darwin": {
             "prefix":["/", "Applications"],


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-3vz251w
  * FT-
  * SENTRY-
  * ZENDESK-98196

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes

Aligned rest of Houdini executables to correct ones for Core, Apprentice and FX.

## Test

Test launching each on of them, the applauncher log should state that correct executable is launched.
