### PR TITLE
Add application variant to launch message

### DIFF
--- a/doc/source/release/release_notes.rst
+++ b/doc/source/release/release_notes.rst
@@ -8,7 +8,8 @@
 Release Notes
 *************
 
-.. release:: upcoming
+.. release:: 1.0.8
+    :date: 2022-12-14
 
     .. change:: fixed
         :tags: houdini

--- a/source/ftrack_application_launcher/__init__.py
+++ b/source/ftrack_application_launcher/__init__.py
@@ -435,7 +435,10 @@ class ApplicationLauncher(object):
         self._conform_environment(environment)
 
         success = True
-        message = '{0} application started.'.format(application['label'])
+        message = '{0}{1} application started.'.format(
+            application['label'],
+            ' ' + application['variant'] if application.get('variant') else '',
+        )
 
         try:
             options = dict(env=environment, close_fds=True)


### PR DESCRIPTION
- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
It is quite convenient to see variant with the application label:
![image](https://user-images.githubusercontent.com/638393/211151805-d9b96062-7911-4cfd-83fd-f07dda1341db.png)

What do you think?
